### PR TITLE
Add instructions for running in Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,16 @@ A script to generate a keymap for your Planck/Preonic/ortho/split ortho keyboard
 ~~It's created in Python, so you'll need that on your system to run the script.~~
 The new version is created in PowerShell so you'll need that on your system - see the following guide on [how to install PowerShell](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell?view=powershell-7.2).
 
+### Run inside a PowerShell Docker container
+If you don't want to install PowerShell, but do have Docker, then you can run the generator script from inside the official PowerShell image. Execute the following from the same directory that contains `CreateOrthoKeymapSVG.ps1` to get a PowerShell prompt in that same directory:
+
+```
+docker container run -it \
+--mount type=bind,source="$(pwd)",target=/app \
+mcr.microsoft.com/powershell \
+pwsh -WorkingDirectory /app
+```
+
 _The old Python version is no longer maintained, but still available [OldCreateOrthoKeymapSVG.py](OldCreateOrthoKeymapSVG.py)_
 
 ## Download the script


### PR DESCRIPTION
wanted to use this wonderful script without needing to install PowerShell on my system. The proposed change has instructions for using Docker to fire up a PowerShell prompt, mounted to the current working directory. You can then invoke CreateOrthoKeymapSVG.ps1 interactively and write the output back to your system, without ever needing to install PowerShell. I'm kind of a Docker novice so I'm not entirely sure if this is 100% the best way to achieve this, but it works.

I realize that the proposed changes have nothing to actually do with CreateOrthoKeymapSVG.ps1 but I think it will help people (like me) who are unfamiliar with PowerShell.